### PR TITLE
error checking for illegal instructions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Amjad50"
+    assignees:
+      - "Amjad50"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+
+  - package-ecosystem: "cargo"
+    directory: "/mizu-core"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Amjad50"
+    assignees:
+      - "Amjad50"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+
+  - package-ecosystem: "cargo"
+    directory: "/save_state"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Amjad50"
+    assignees:
+      - "Amjad50"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+
+  - package-ecosystem: "cargo"
+    directory: "/save_state_derive"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Amjad50"
+    assignees:
+      - "Amjad50"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "Amjad50"
+    assignees:
+      - "Amjad50"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Security audit
-      uses: rustsec/audit-check@v1
+      uses: rustsec/audit-check@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up SFML

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -19,23 +23,25 @@ jobs:
     - name: Download apt packages
       run: |
         sudo apt-get update -y 
-        sudo apt-get install -y libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libx11-xcb-dev libxcb-image0-dev libxrandr-dev libxcb-randr0-dev libudev-dev libfreetype6-dev libglew-dev libjpeg8-dev libgpgme11-dev libsndfile1-dev libopenal-dev libjpeg62 libxcursor-dev cmake libclang-dev clang libasound2-dev bison
+        sudo apt-get install -y libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libx11-xcb-dev libxcb-image0-dev libxrandr-dev libxcb-randr0-dev libudev-dev libfreetype6-dev libglew-dev libjpeg8-dev libgpgme11-dev libsndfile1-dev libopenal-dev libjpeg62 libxcursor-dev cmake libclang-dev clang libasound2-dev bison libxi-dev
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
           override: true
           target: x86_64-unknown-linux-gnu
+
+    - uses: Swatinem/rust-cache@v2
+
     - name: Install cargo-tarpaulin
-      uses: actions-rs/install@v0.1
+      uses: taiki-e/install-action@v2
       with:
-        crate: cargo-tarpaulin
-        version: latest
-        use-tool-cache: true
-    - uses: actions/checkout@v2
+        tool: cargo-tarpaulin
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    - uses: actions-rs/audit-check@v1
+    - name: Security audit
+      uses: rustsec/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up SFML
@@ -58,4 +64,4 @@ jobs:
         export SFML_INCLUDE_DIR=$GITHUB_WORKSPACE/sfml_install/usr/local/include
         export SFML_LIBS_DIR=$GITHUB_WORKSPACE/sfml_install/usr/local/lib
         sh ./.github/install_and_run_tests.sh
-    - uses: codecov/codecov-action@v1.0.11
+    - uses: codecov/codecov-action@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "sfml"
-version = "0.24.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941169c8be33fd81c006591c0dff6056f94bca0bff6057a262ba946bdb6dc0ed"
+checksum = "33401fa26a81e4b9542062e13c2b6451b37f04d6af0bc495968cca5d3b1a61bf"
 dependencies = [
  "bitflags 2.9.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,18 +1173,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
  "fixed-vec-deque",
  "save_state",
  "sha2",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "zstd",
 ]
 
@@ -675,7 +675,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "raw-window-handle",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "versions",
  "wfd",
  "which",
@@ -1079,7 +1079,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ dependencies = [
  "paste",
  "save_state_derive",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1278,11 +1278,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1298,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "mizu-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,18 +206,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["emulators"]
 mizu-core = { version = "1.2.0", path = "mizu-core" }
 sfml = { version = "0.25", default-features = false, features = ["graphics"] }
 ringbuf = "0.4"
-clap = { version = "4.0", features = ["string"] }
+clap = { version = "4.5", features = ["string"] }
 native-dialog = "0.9"
 directories-next = "2.0"
 dynwave = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["emulators"]
 
 [dependencies]
 mizu-core = { version = "1.2.0", path = "mizu-core" }
-sfml = { version = "0.24", default-features = false, features = ["graphics"] }
+sfml = { version = "0.25", default-features = false, features = ["graphics"] }
 ringbuf = "0.4"
 clap = { version = "4.0", features = ["string"] }
 native-dialog = "0.9"

--- a/mizu-core/Cargo.toml
+++ b/mizu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mizu-core"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Amjad Alsharafi <amjadsharafi10@gmail.com>"]
 edition = "2021"
 description = "The core library implementation of all Gameboy emulation for Mizu"

--- a/mizu-core/src/cpu.rs
+++ b/mizu-core/src/cpu.rs
@@ -46,6 +46,11 @@ pub struct CpuRegisters {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RunError {
+    IllegalInstruction
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CpuState {
     Normal,
     InfiniteLoop,
@@ -151,7 +156,7 @@ impl Cpu {
         cpu
     }
 
-    pub fn next_instruction<P: CpuBusProvider>(&mut self, bus: &mut P) -> Result<CpuState, &'static str> {
+    pub fn next_instruction<P: CpuBusProvider>(&mut self, bus: &mut P) -> Result<CpuState, RunError> {
         if bus.stopped() {
             self.advance_bus(bus);
             return Ok(CpuState::Stopped);
@@ -450,7 +455,7 @@ impl Cpu {
         &mut self,
         instruction: Instruction,
         bus: &mut P,
-    ) -> Result<CpuState, &'static str> {
+    ) -> Result<CpuState, RunError> {
         let src = self.read_operand(instruction.src, bus);
 
         let mut cpu_state = CpuState::Normal;
@@ -924,8 +929,8 @@ impl Cpu {
                 bus.enter_stop_mode();
                 Ok(0)
             }
-            Opcode::Illegal => Err("undecodable opcode"),
-            Opcode::Prefix => Err("unreachable"),
+            Opcode::Illegal => Err(RunError::IllegalInstruction),
+            Opcode::Prefix => unreachable!(),
         }?;
 
         // DEBUG

--- a/mizu-core/src/cpu.rs
+++ b/mizu-core/src/cpu.rs
@@ -233,7 +233,14 @@ impl Cpu {
             instruction = Instruction::from_prefix(self.fetch_next_pc(bus), pc);
         }
 
-        self.exec_instruction(instruction, bus)
+        match self.exec_instruction(instruction, bus) {
+            Err(e) => {
+                // do not add pc from the last fetch ^
+                self.reg_pc = pc;
+                Err(e)
+            }
+            Ok(r) => Ok(r)
+        }
     }
 }
 

--- a/mizu-core/src/lib.rs
+++ b/mizu-core/src/lib.rs
@@ -164,7 +164,7 @@ impl GameBoy {
         const PPU_CYCLES_PER_FRAME: u32 = 456 * 154;
         let mut cycles = 0u32;
         while cycles < PPU_CYCLES_PER_FRAME {
-            self.cpu.next_instruction(&mut self.bus);
+            self.cpu.next_instruction(&mut self.bus).unwrap();
             cycles += self.bus.elapsed_ppu_cycles();
         }
     }

--- a/mizu-core/src/tests/mod.rs
+++ b/mizu-core/src/tests/mod.rs
@@ -149,12 +149,12 @@ impl TestingGameBoy {
     }
 
     pub fn clock_until_infinte_loop(&mut self) {
-        while self.cpu.next_instruction(&mut self.bus) != CpuState::InfiniteLoop {}
+        while self.cpu.next_instruction(&mut self.bus).unwrap() != CpuState::InfiniteLoop {}
     }
 
     pub fn clock_until_breakpoint(&mut self) -> CpuRegisters {
         loop {
-            if let CpuState::Breakpoint(regs) = self.cpu.next_instruction(&mut self.bus) {
+            if let CpuState::Breakpoint(regs) = self.cpu.next_instruction(&mut self.bus).unwrap() {
                 return regs;
             }
         }


### PR DESCRIPTION
I need to be able to run ill-formed code, so here is a pull-request which makes mizu-core not panic when single-stepping across an illegal opcode. I actually ran into this with the `jr fdh` instruction, which seems to jump into the offset byte, thus pointing the program counter at the illegal opcode 0xfd.

* illegal opcodes are still not handled or decoded or implemented; this just makes it possible to keep single-stepping and it returns an `Err<&'static str>` if it can't execute the instruction
* Other parts of the codebase now `.unwrap()` so the semantics are the same; this might be worth reconsidering

